### PR TITLE
Replace named captures (?P<type_i>...) with indexed captures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sscanf"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["mich101mich <mich101mich@gmail.com>"]
 edition = "2018"
 description = "A sscanf (inverse of format!()) Macro based on Regex"
@@ -12,7 +12,7 @@ categories = ["parsing"]
 exclude = ["/.vscode/*", "/sscanf_macro/", "/.gitignore", "/.github/*", "/*.bat", "/*.sh"]
 
 [dependencies]
-sscanf_macro = { path = "sscanf_macro", version = "=0.2.2"}
+sscanf_macro = { path = "sscanf_macro", version = "=0.3.0"}
 regex = "1.5"
 const_format = "0.2"
 lazy_static = "1.4"

--- a/src/error.rs
+++ b/src/error.rs
@@ -31,15 +31,12 @@ pub enum Error<'input> {
     /// assert!(result.is_err());
     /// let err = result.unwrap_err();
     ///
-    /// assert_eq!(err.to_string(), r#"scanf: Failed to match string "text" against regex ^a(?P<type_1>.+?)$"#);
-    /// assert_eq!(format!("{:?}", err), r#"RegexMatchFailed { input: "text", regex: ^a(?P<type_1>.+?)$ }"#);
+    /// assert_eq!(err.to_string(), r#"scanf: Failed to match string "text" against regex ^a(.+?)$"#);
+    /// assert_eq!(format!("{:?}", err), r#"RegexMatchFailed { input: "text", regex: ^a(.+?)$ }"#);
     ///
     /// if let Error::RegexMatchFailed { input, regex } = err {
     ///     assert_eq!(input, "text");
-    ///     assert_eq!(regex.as_str(), r"^a(?P<type_1>.+?)$");
-    ///     //             actual regex: ^a.+?$
-    ///     // the ?P<type_1> part is a named capture group which allows scanf to access the
-    ///     // matched content under the name "type_1" for parsing. See scanf_get_regex!()
+    ///     assert_eq!(regex.as_str(), r"^a(.+?)$");
     /// } else {
     ///     panic!("Unexpected error: {:?}", err);
     /// }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,7 +164,10 @@
 //! assert_eq!(parsed, Ok(("rando", "m Text")));
 //! ```
 //!
-//! As mentioned above, `'{'` `'}'` have to be escaped with a `'\'`. This means that:
+//! Note: If you use any unescaped ( ) in your regex, you have to prevent them from forming
+//! a capture group by adding a `?:` at the beginning: `{:/..(..)../}` becomes `{:/..(?:..)../}`.
+//!
+//! As mentioned previously, `'{'` `'}'` have to be escaped with a `'\'`. This means that:
 //! - `"{"` or `"}"` would give a compiler error
 //! - `"\{"` or `"\}"` lead to a `"{"` or `"}"` inside of the regex
 //!   - curly brackets have a special meaning in regex as counted repetition
@@ -360,7 +363,7 @@
 /// assert_eq!(parsed, Ok(('N', 36, 'E', 21)));
 ///
 /// let input = "4-5 t: ftttttrvts";
-/// let parsed = scanf!(input, "{usize}-{usize} {char}: {}", str); // mixed types (discouraged)
+/// let parsed = scanf!(input, "{usize}-{usize} {}: {str}", char); // mixed types (discouraged)
 /// assert_eq!(parsed, Ok((4, 5, 't', "ftttttrvts")));
 /// ```
 pub use sscanf_macro::scanf;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -367,30 +367,24 @@ pub use sscanf_macro::scanf;
 
 /// Same as [`scanf`], but returns the Regex without running it. Useful for Debugging or Efficiency.
 ///
-/// The Placeholders can be obtained by capturing the Regex and using either Name or index of the Group.
-///
-/// The Name is always `type_i` where `i` is the index of the type in the `scanf` call, starting at `1`.
-///
-/// Indices start at `1` as with any Regex, however it is possible that non-std implementations
-/// of [`RegexRepresentation`] create their own Capture Groups and distort the order, so use with
-/// caution.
+/// The Placeholders can be obtained by capturing the Regex and using the 1-based index of the Group.
 ///
 /// ```
 /// use sscanf::scanf_get_regex;
 /// let input = "Test 5 -2";
 /// let regex = scanf_get_regex!("Test {} {}", usize, i32);
-/// assert_eq!(regex.as_str(), r"^Test (?P<type_1>\+?\d{1,20}) (?P<type_2>[-+]?\d{1,10})$");
+/// assert_eq!(regex.as_str(), r"^Test (\+?\d{1,20}) ([-+]?\d{1,10})$");
 ///
 /// let output = regex.captures(input);
 /// assert!(output.is_some());
 /// let output = output.unwrap();
 ///
-/// let capture_5 = output.name("type_1");
+/// let capture_5 = output.get(1);
 /// assert!(capture_5.is_some());
 /// assert_eq!(capture_5.unwrap().as_str(), "5");
 /// assert_eq!(capture_5, output.get(1));
 ///
-/// let capture_negative_2 = output.name("type_2");
+/// let capture_negative_2 = output.get(2);
 /// assert!(capture_negative_2.is_some());
 /// assert_eq!(capture_negative_2.unwrap().as_str(), "-2");
 /// assert_eq!(capture_negative_2, output.get(2));

--- a/src/regex_representation.rs
+++ b/src/regex_representation.rs
@@ -6,9 +6,11 @@
 /// The Regular Expression should match the string representation as exactly as possible.
 /// Any incorrect matches might be caught in the from_str parsing, but that might cause this
 /// regex to take characters that could have been matched by other placeholders, leading to
-/// unexpected parsing failures. Also: Since `scanf` only returns an `Option` it will just say
-/// `None` whether the regex matching failed or the parsing failed, so you should avoid parsing
-/// failures by writing a proper regex as much as possible.
+/// unexpected parsing failures.
+/// 
+/// **Note:** The parser uses indexing to access capture groups. To avoid messing with the
+/// indexing, the regex should not contain any capture groups by either not using round brackets
+/// `(<content>)` or by escaping the round brackets `(?:<content>)`.
 ///
 /// ## Example
 /// Let's say we want to add a Fraction parser

--- a/src/regex_representation.rs
+++ b/src/regex_representation.rs
@@ -9,8 +9,10 @@
 /// unexpected parsing failures.
 /// 
 /// **Note:** The parser uses indexing to access capture groups. To avoid messing with the
-/// indexing, the regex should not contain any capture groups by either not using round brackets
-/// `(<content>)` or by escaping the round brackets `(?:<content>)`.
+/// indexing, the regex should not contain any capture groups by using the `(?:)` syntax
+/// on any round brackets:
+/// 
+/// Any `(<content>)` should be replaced with `(?:<content>)`
 ///
 /// ## Example
 /// Let's say we want to add a Fraction parser
@@ -26,6 +28,7 @@
 ///     /// matches an optional '-' or '+' followed by a number.
 ///     /// possibly with a '/' and another Number
 ///     const REGEX: &'static str = r"[-+]?\d+(?:/\d+)?";
+///     //                                     ^^ escapes the group. Has to be used on any ( ) in a regex.
 /// }
 /// impl std::str::FromStr for Fraction {
 ///     type Err = std::num::ParseIntError;

--- a/sscanf_macro/Cargo.toml
+++ b/sscanf_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sscanf_macro"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["mich101mich <mich101mich@gmail.com>"]
 edition = "2018"
 description = "Proc-Macros for the sscanf Crate. Not meant to be used as a standalone Crate"

--- a/sscanf_macro/src/chrono.rs
+++ b/sscanf_macro/src/chrono.rs
@@ -60,7 +60,7 @@ fn get_date_fmt(
     let pad = |def| padding.unwrap_or(def);
     let pad_to = |def, n| {
         let padding = pad(def);
-        let mut fmt = String::from("(");
+        let mut fmt = String::from("(?:");
         for i in 0..n {
             if i != 0 {
                 fmt += "|";
@@ -118,8 +118,8 @@ fn get_date_fmt(
         'k' => format!(r"(?:{}\d|1\d|2[0-3])", pad(" ")),
         'I' => format!(r"(?:{}[1-9]|1[0-2])", pad("0")),
         'l' => format!(r"(?:{}[1-9]|1[0-2])", pad(" ")),
-        'P' => "(am|pm)".to_string(),
-        'p' => "(AM|PM)".to_string(),
+        'P' => "(?:am|pm)".to_string(),
+        'p' => "(?:AM|PM)".to_string(),
         'M' => format!(r"(?:{}\d|[1-5]\d)", pad("0")),
         'S' => format!(r"(?:{}\d|[1-5]\d|60)", pad("0")),
         'f' => r"\d{9}".to_string(),

--- a/sscanf_macro/src/format_config.rs
+++ b/sscanf_macro/src/format_config.rs
@@ -1,5 +1,4 @@
 use super::*;
-use std::fmt::Write;
 
 pub(crate) fn parse_format_string(
     input: &ScanfInner,
@@ -11,19 +10,13 @@ pub(crate) fn parse_format_string(
     let mut regex = vec![];
     let mut current_regex = String::from("^");
 
-    // name of the next placeholder
-    let mut name_index = 1;
-
     // keep the iterator as a variable to allow peeking and advancing in a sub-function
     let mut iter = input.fmt.chars().enumerate().peekable();
 
     while let Some((i, c)) = iter.next() {
         if c == '{' {
-            if let Some(mut ph) = parse_bracket_content(&mut iter, input, i)? {
-                ph.name = format!("type_{}", name_index);
-                name_index += 1;
-
-                write!(current_regex, "(?P<{}>", ph.name).unwrap();
+            if let Some(ph) = parse_bracket_content(&mut iter, input, i)? {
+                current_regex.push('(');
                 regex.push(current_regex);
                 current_regex = String::from(")");
 
@@ -138,7 +131,6 @@ pub(crate) fn parse_bracket_content<I: Iterator<Item = (usize, char)>>(
             );
         } else if c == '}' {
             return Ok(Some(PlaceHolder {
-                name: String::new(),
                 type_token,
                 config: has_config.then(|| (config, config_start)),
                 span: (start, i),

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -66,15 +66,12 @@ fn get_regex() {
     let regex = scanf_get_regex!("Test {usize} {f32} {{}} {}!", std::string::String);
     assert_eq!(
         regex.as_str(),
-        r"^Test (?P<type_1>\+?\d{1,20}) (?P<type_2>[-+]?\d+\.?\d*) \{\} (?P<type_3>.+?)!$"
+        r"^Test (\+?\d{1,20}) ([-+]?\d+\.?\d*) \{\} (.+?)!$"
     );
 
     let output = regex.captures(input);
     assert!(output.is_some());
     let output = output.unwrap();
-    assert_eq!(output.name("type_1").map(|m| m.as_str()), Some("5"));
-    assert_eq!(output.name("type_2").map(|m| m.as_str()), Some("1.4"));
-    assert_eq!(output.name("type_3").map(|m| m.as_str()), Some("bob"));
     assert_eq!(output.get(1).map(|m| m.as_str()), Some("5"));
     assert_eq!(output.get(2).map(|m| m.as_str()), Some("1.4"));
     assert_eq!(output.get(3).map(|m| m.as_str()), Some("bob"));
@@ -162,7 +159,7 @@ fn invalid_regex_representation() {
     impl RegexRepresentation for Test {
         const REGEX: &'static str = ")";
     }
-    scanf!("hi", "{}", Test).unwrap();
+    scanf!("hi", "{Test}").unwrap();
 }
 
 #[test]
@@ -236,6 +233,22 @@ fn error_lifetime() {
         Ok(())
     }
     foo().unwrap();
+}
+
+#[test]
+#[should_panic(expected = "scanf: Regex has 1 more capture groups than expected.")]
+fn custom_regex_with_capture_group() {
+    struct Test(usize);
+    impl FromStr for Test {
+        type Err = <usize as FromStr>::Err;
+        fn from_str(s: &str) -> Result<Self, Self::Err> {
+            s.parse().map(Test)
+        }
+    }
+    impl RegexRepresentation for Test {
+        const REGEX: &'static str = "(.*)";
+    }
+    scanf!("5", "{Test}").unwrap();
 }
 
 #[test]


### PR DESCRIPTION
## Advantages
- Faster access (names require HashMap lookup)
- Regex printed by `Error` or `scanf_get_regex` is _much_ easier to read without the ?P<>

## Disadvantages
- Any and all ( ) in a custom regex have to be non-grouped with (?: )
  - This can currently only be checked at runtime and with no way of finding the origin of the ( )

=> Breaks any Code that has a `RegexRepresentation` or a `{:/regex/}` that uses ( )