### PR TITLE
Update strsim from 0.10 to 0.11

### DIFF
--- a/sscanf_macro/Cargo.toml
+++ b/sscanf_macro/Cargo.toml
@@ -17,7 +17,7 @@ syn = { version = "2.0.1", features = ["parsing", "derive", "full"] }
 quote = "1.0.0"
 proc-macro2 = "1.0.60"
 regex-syntax = "0.6.0"
-strsim = "0.10.0"
+strsim = "0.11.1"
 convert_case = "0.6.0"
 
 [target.'cfg(not(msrv_build))'.dependencies]


### PR DESCRIPTION
I updated ~~a couple of dependencies~~ one dependency across SemVer boundaries.

----

Update `strsim` depedency in `sscanf_macro` from 0.10 to 0.11.

https://github.com/rapidfuzz/strsim-rs/blob/v0.11.1/CHANGELOG.md#0110---2024-01-07

~~Update `thiserror` dev-dependency in `sscanf` from 1.0.2 to 2.~~ (**removed from PR for MSRV reasons**)

https://github.com/dtolnay/thiserror/releases/tag/2.0.0

----

I did not touch `convert_case`, which is at 0.6.x but has 0.8.x available, because it seemed like upstream renaming `Case::ScreamingSnake` to `Case::Constant` might have API impacts in this crate.

I did not touch `regex-syntax`, which is at 0.6.x but has 0.8.x available, because there were significant API changes and, without particular familiarity with the code, porting seemed nontrivial.

----

I confirmed that `cargo test --workspace` still passes.